### PR TITLE
Add patch for `InventoryUtils.FindThumbnailPaths` in Sandcastle

### DIFF
--- a/KSPCommunityModFixes.ckan
+++ b/KSPCommunityModFixes.ckan
@@ -9,3 +9,5 @@ depends:
     min_version: 4.2.3
   - name: Harmony2
     min_version: 2.2.1
+  - name: KSPPluginLoader
+    min_version: 1.0.0

--- a/KSPCommunityModFixes.sln
+++ b/KSPCommunityModFixes.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KSPCommunityModFixes", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KSPCommunityModFixes.MechJeb2", "src\KSPCommunityModFixes.MechJeb2\KSPCommunityModFixes.MechJeb2.csproj", "{BCF60A23-4F5B-408D-BE79-888BEBA35F33}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KSPCommunityModFixes.Sandcastle", "src\KSPCommunityModFixes.Sandcastle\KSPCommunityModFixes.Sandcastle.csproj", "{7F9888F6-02BE-4629-88DA-184D28254A89}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,18 @@ Global
 		{BCF60A23-4F5B-408D-BE79-888BEBA35F33}.Release|x64.Build.0 = Release|Any CPU
 		{BCF60A23-4F5B-408D-BE79-888BEBA35F33}.Release|x86.ActiveCfg = Release|Any CPU
 		{BCF60A23-4F5B-408D-BE79-888BEBA35F33}.Release|x86.Build.0 = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|x64.Build.0 = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F9888F6-02BE-4629-88DA-184D28254A89}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,6 +64,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{BD381523-5761-8720-4F34-80C99D5C11E1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{BCF60A23-4F5B-408D-BE79-888BEBA35F33} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7F9888F6-02BE-4629-88DA-184D28254A89} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D9B233F0-AFF7-419E-A4EE-04E26A75F140}

--- a/deps/depset1.ckan
+++ b/deps/depset1.ckan
@@ -11,8 +11,9 @@
     "kind": "metapackage",
     "depends": [
         { "name": "Harmony2" },
+        { "name": "KSPPluginLoader" },
         { "name": "MechJeb2" },
-        { "name": "KSPPluginLoader" }
+        { "name": "Sandcastle" }
     ],
     "recommends": [
         { "name": "KSPCommunityFixes" },

--- a/src/GameData/KSPCommunityModFixes.cfg
+++ b/src/GameData/KSPCommunityModFixes.cfg
@@ -3,4 +3,5 @@
 KSPCommunityModFixes
 {
     MechJeb2 = true
+    Sandcastle = true
 }

--- a/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
+++ b/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <KSPMCFPlugin>true</KSPMCFPlugin>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Add mod-specific dependencies here. The common dependencies (on KSPMCF
+      and Harmony) are handled in Directory.Build.Props and do not need to
+      be added here.
+    -->
+
+    <Reference Include="Sandcastle.dll">
+      <HintPath>$(DepSet1)\WildBlueIndustries\Sandcastle\Plugin\Sandcastle.dll</HintPath>
+      <Private>false</Private>
+      <CKANIdentifier>Sandcastle</CKANIdentifier>
+      <KSPAssemblyName>Sandcastle</KSPAssemblyName>
+      <KSPAssemblyVersion>1.0</KSPAssemblyVersion>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
+++ b/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
@@ -13,8 +13,8 @@
     <Reference Include="WildBlueCore.dll">
       <HintPath>$(DepSet1)\WildBlueIndustries\00WildBlueCore\Plugins\WildBlueCore.dll</HintPath>
       <Private>false</Private>
-      <CKANIdentifier>Sandcastle</CKANIdentifier>
-      <KSPAssemblyName>Sandcastle</KSPAssemblyName>
+      <CKANIdentifier>WilBlueCore</CKANIdentifier>
+      <KSPAssemblyName>WildBlueCore</KSPAssemblyName>
       <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
     </Reference>
 

--- a/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
+++ b/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
@@ -10,19 +10,20 @@
       be added here.
     -->
 
+    <Reference Include="WildBlueCore.dll">
+      <HintPath>$(DepSet1)\WildBlueIndustries\00WildBlueCore\Plugins\WildBlueCore.dll</HintPath>
+      <Private>false</Private>
+      <CKANIdentifier>Sandcastle</CKANIdentifier>
+      <KSPAssemblyName>Sandcastle</KSPAssemblyName>
+      <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
+    </Reference>
+
     <Reference Include="Sandcastle.dll">
       <HintPath>$(DepSet1)\WildBlueIndustries\Sandcastle\Plugin\Sandcastle.dll</HintPath>
       <Private>false</Private>
       <CKANIdentifier>Sandcastle</CKANIdentifier>
       <KSPAssemblyName>Sandcastle</KSPAssemblyName>
-      <KSPAssemblyVersion>1.0</KSPAssemblyVersion>
-    </Reference>
-
-    <Reference Include="KSPPluginLoader.dll">
-      <HintPath>$(DepSet1)\000_PluginLoader\Plugins\KSPPluginLoader.dll</HintPath>
-      <Private>false</Private>
-      <KSPAssemblyName>KSPPluginLoader</KSPAssemblyName>
-      <KSPAssemblyVersion>1.0.0</KSPAssemblyVersion>
+      <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
+++ b/src/KSPCommunityModFixes.Sandcastle/KSPCommunityModFixes.Sandcastle.csproj
@@ -17,5 +17,12 @@
       <KSPAssemblyName>Sandcastle</KSPAssemblyName>
       <KSPAssemblyVersion>1.0</KSPAssemblyVersion>
     </Reference>
+
+    <Reference Include="KSPPluginLoader.dll">
+      <HintPath>$(DepSet1)\000_PluginLoader\Plugins\KSPPluginLoader.dll</HintPath>
+      <Private>false</Private>
+      <KSPAssemblyName>KSPPluginLoader</KSPAssemblyName>
+      <KSPAssemblyVersion>1.0.0</KSPAssemblyVersion>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/src/KSPCommunityModFixes.Sandcastle/SandcastleScenario_OnAwake.cs
+++ b/src/KSPCommunityModFixes.Sandcastle/SandcastleScenario_OnAwake.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Sandcastle;
+using Sandcastle.Inventory;
+
+namespace KSPCommunityModFixes.Sandcastle;
+
+/// <summary>
+/// <c>InventoryUtils.FindThumbnailPaths</c> scans the entirety of GameData.
+/// The list it computes from this is never used anywhere so we just delete
+/// the one call to it.
+/// </summary>
+[HarmonyPatch(typeof(SandcastleScenario), nameof(SandcastleScenario.OnAwake))]
+static class SandcastleScenario_OnAwake_Patch
+{
+    static IEnumerable<CodeInstruction> Transpiler(
+        IEnumerable<CodeInstruction> instructions,
+        ILGenerator gen
+    )
+    {
+        var method = Tools.GetMethodInfo(() => InventoryUtils.FindThumbnailPaths());
+
+        var matcher = new CodeMatcher(instructions, gen);
+        matcher.Repeat(matcher =>
+        {
+            matcher.MatchStartForward(new CodeMatch(OpCodes.Call, method)).RemoveInstruction();
+        });
+
+        return matcher.Instructions();
+    }
+}

--- a/src/KSPCommunityModFixes.Sandcastle/packages.lock.json
+++ b/src/KSPCommunityModFixes.Sandcastle/packages.lock.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8.1": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net481": "1.0.3"
+        }
+      },
+      "JsonPoke": {
+        "type": "Transitive",
+        "resolved": "1.2.0",
+        "contentHash": "AW7iyzudTA4VzW3pYjTzy+MucrF+wUWKQulqx/EnqvlqLwVseNk2nqlWpTRySItQCgBv0w7o/dqTN4wj0tWJhA=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net481": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "Vv/20vgHS7VglVOVh8J3Iz/MA+VYKVRp9f7r2qiKBMuzviTOmocG70yq0Q8T5OTmCONkEAIJwETD1zhEfLkAXQ=="
+      },
+      "kspcommunitymodfixes": {
+        "type": "Project",
+        "dependencies": {
+          "JsonPoke": "[1.2.0, )"
+        }
+      }
+    }
+  }
+}

--- a/src/KSPCommunityModFixes/KSPCommunityModFixesAssemblyAttribute.cs
+++ b/src/KSPCommunityModFixes/KSPCommunityModFixesAssemblyAttribute.cs
@@ -6,4 +6,4 @@ namespace KSPCommunityModFixes;
 /// This attribute is used to mark assemblies that contains KSPCMF fixes.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
-internal sealed class KSPCommunityModFixesAssemblyAttribute : Attribute { }
+public sealed class KSPCommunityModFixesAssemblyAttribute : Attribute { }


### PR DESCRIPTION
Upstream PR: https://github.com/Angel-125/Sandcastle/pull/24

This one method takes about 700ms on my game instance during scene switches. It spends that time scanning the entire GameData folder for thumbnail paths, but never actually uses the resulting list. This patch just deletes the one call to the method.

Here's a supporting profile
<img width="1662" height="809" alt="image" src="https://github.com/user-attachments/assets/e693e692-bfb0-4d47-8030-52342485615a" />
